### PR TITLE
Add completion message argument to DynGenDef.send

### DIFF
--- a/src/Classes/DynGen.sc
+++ b/src/Classes/DynGen.sc
@@ -39,26 +39,26 @@ DynGenDef {
 		code = File.readAllString(path.asAbsolutePath);
 	}
 
-	send {|server|
+	send {|server, completionMsg|
 		var servers = (server ?? { Server.allBootedServers }).asArray;
 		servers.do { |each|
 			if(each.hasBooted.not) {
 				"Server % not running, could not send DynGenDef.".format(server.name).warn
 			};
-			this.prSendScript(each);
+			this.prSendScript(each, completionMsg);
 		}
 	}
 
-	prSendScript {|server|
-		var message = [\cmd, \dyngenscript, hash, code];
-		if(message.flatten.size < (65535 div: 4), {
+	prSendScript {|server, completionMsg|
+		var message = [\cmd, \dyngenscript, hash, code, completionMsg];
+		if(message.flatten(2).size < (65535 div: 4), {
 			server.sendMsg(*message);
 		}, {
-			this.prSendFile(server);
+			this.prSendFile(server, completionMsg);
 		});
 	}
 
-	prSendFile {|server|
+	prSendFile {|server, completionMsg|
 		var tmpFilePath = PathName.tmp +/+ "%_%".format(hash.asString, counter);
 		counter = counter + 1;
 
@@ -74,7 +74,7 @@ DynGenDef {
 			f.write(code);
 		});
 
-		server.sendMsg(\cmd, \dyngenfile, hash, tmpFilePath);
+		server.sendMsg(\cmd, \dyngenfile, hash, tmpFilePath, completionMsg);
 
 		fork {
 			var deleteSuccess;

--- a/src/HelpSource/Classes/DynGenDef.schelp
+++ b/src/HelpSource/Classes/DynGenDef.schelp
@@ -51,6 +51,8 @@ In case the script is too big, the script will be saved to a local temp file and
 argument:: server
 The server on which the DynGenDef should be registered.
 If no server is provided, LINK::Classes/Server#*allBootedServers:: will be used.
+argument:: completionMsg
+An optional OSC message that will be executed by the server after the DynGenDef has been registered on the server.
 
 METHOD:: load
 Loads the content of a file to the code variable.


### PR DESCRIPTION
Implements #29

One question @spacechild1 - I assume that the server takes care of deleting the RT allocated completion message buffer? I failed to find any documentation on that, but seems to make the most sense?
Also I am assuming that I need to clone the buffer b/c *args gets probably deleted by the server.