### PR TITLE
fix/improve CMakeLists.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             -S . \
             -B build \
             -DSC_PATH=./supercollider \
-            -DCMAKE_INSTALL_PREFIX=./install
+            -DSC_INSTALL_DIR=./install
         cmake --build build --config Release
         cmake --install build --config Release
     - name: upload artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,14 @@ option(SUPERNOVA "Build plugins for supernova" OFF)
 message(STATUS "SUPERNOVA: ${SUPERNOVA}")
 
 # default installation path
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    if (WIN32)
-        file(TO_CMAKE_PATH "$ENV{LOCALAPPDATA}" _localappdata)
-        set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "${_localappdata}/SuperCollider/Extensions/")
-    elseif(APPLE)
-        set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "$ENV{HOME}/Library/Application Support/SuperCollider/Extensions/")
-    else()
-        set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "$ENV{HOME}/.local/share/SuperCollider/Extensions/")
-    endif()
+if (WIN32)
+    set(SC_INSTALL_DIR "$ENV{LOCALAPPDATA}/SuperCollider/Extensions/" CACHE PATH "Installation directoy")
+elseif(APPLE)
+    set(SC_INSTALL_DIR "~/Library/Application Support/SuperCollider/Extensions/" CACHE PATH "Installation directoy")
+else()
+    set(SC_INSTALL_DIR "~/.local/share/SuperCollider/Extensions/" CACHE PATH "Installation directoy")
 endif()
-
-message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "SC_INSTALL_DIR: ${SC_INSTALL_DIR}")
 
 #--------------------- WDL/EEL2 ---------------------------#
 
@@ -140,7 +136,7 @@ endif()
 
 #--------------------- installation ---------------------------#
 
-set(INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}")
+set(INSTALL_DIR "${SC_INSTALL_DIR}/${PROJECT_NAME}")
 
 install(TARGETS DynGen LIBRARY DESTINATION "${INSTALL_DIR}/plugins")
 if (MSVC)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake --install build --config Release
 ```
 
 By default, DynGen will be installed to the default SuperCollider user extension directory which can be located by evaluating `Platform.userExtensionDir;` within sclang.
-You can override the installation path by setting the `CMAKE_INSTALL_PREFIX` variable.
+You can override the installation path by setting the `SC_INSTALL_DIR` variable.
 
 ## Demo
 


### PR DESCRIPTION
- make `SC_SRC_PATH` a cache variable
- add `SC_INSTALL_PATH` cache variable and set it to default SC extension directory
- add `SUPERNOVA` option
- `DynGen_common` INTERFACE library for all properties shared between the `DynGen` and `DynGen_supernova` UGen
- bump minimum required version to 3.15 for better INTERFACE library support
- fix linker error with Msys2
- remove library prefix on all platforms (not only on Linux)
- add headers to sources so they show up in IDEs
- do not include `supercollider/common` (not necessary and not part of the public API)
- simplify/improve installation:
  - put plugins in `plugins` folder
  - install folders instead of globbing files
  - also install `README.md` and `LICENSE`
- update build instructions in `README.md`

Tested successfully on Windows and Linux.