### PR TITLE
add 'update' argument to DynGenDef -send method

### DIFF
--- a/src/Classes/DynGen.sc
+++ b/src/Classes/DynGen.sc
@@ -45,23 +45,24 @@ DynGenDef {
 		}
 	}
 
-	send {|server, completionMsg|
+	send {|server, update=true, completionMsg|
 		var servers = (server ?? { Server.allBootedServers }).asArray;
 		this.prRegisterParams;
 		servers.do { |each|
 			if(each.hasBooted.not) {
 				"Server % not running, could not send DynGenDef.".format(server.name).warn
 			};
-			this.prSendScript(each, completionMsg);
+			this.prSendScript(each, update, completionMsg);
 		}
 	}
 
-	sendMsg {|completionMsg|
+	sendMsg {|update=true, completionMsg|
 		var message = [
 			\cmd,
 			\dyngenscript,
 			hash,
 			code,
+			update.asInteger,
 			prParams.size,
 		];
 		message = message ++ prParams;
@@ -83,16 +84,16 @@ DynGenDef {
 		});
 	}
 
-	prSendScript {|server, completionMsg|
-		var message = this.sendMsg(completionMsg).asRawOSC;
+	prSendScript {|server, update, completionMsg|
+		var message = this.sendMsg(update, completionMsg).asRawOSC;
 		if(message.size < (65535 div: 4), {
 			server.sendRaw(message);
 		}, {
-			this.prSendFile(server, completionMsg);
+			this.prSendFile(server, update, completionMsg);
 		});
 	}
 
-	prSendFile {|server, completionMsg|
+	prSendFile {|server, update, completionMsg|
 		var message;
 		var tmpFilePath = PathName.tmp +/+ "%_%".format(hash.asString, counter);
 		counter = counter + 1;
@@ -114,6 +115,7 @@ DynGenDef {
 			\dyngenfile,
 			hash,
 			tmpFilePath,
+			update.asInteger,
 			prParams.size,
 		];
 		message = message ++ prParams;

--- a/src/HelpSource/Classes/DynGenDef.schelp
+++ b/src/HelpSource/Classes/DynGenDef.schelp
@@ -53,6 +53,9 @@ In case the script is too big, the script will be saved to a local temp file and
 argument:: server
 The server on which the DynGenDef should be registered.
 If no server is provided, LINK::Classes/Server#*allBootedServers:: will be used.
+argument:: update
+If code::true::, all running DynGen instances of this DynGenDef will be updated to the new code.
+NOTE::Code updates are always asynchronous.::
 argument:: completionMsg
 An optional OSC message that will be executed by the server after the DynGenDef has been registered on the server.
 
@@ -65,7 +68,9 @@ Location of the DynGen script.
 METHOD:: sendMsg
 Returns the OSC message which will be sent to the server.
 This can be used in NRT environments, see LINK::Guides/Non-Realtime-Synthesis::.
-argument:: completionMsg
+argument:: update
+If code::true::, all running DynGen instances of this DynGenDef will be updated to the new code.
+argument::
 An optional OSC message that will be executed by the server after the DynGenDef has been registered on the server.
 
 PRIVATE:: name

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -143,6 +143,8 @@ void Library::buildGenericPayload(World* inWorld, sc_msg_iter* args, const bool 
         return;
     }
 
+    newLibraryEntry->updateUnits = args->geti();
+
     newLibraryEntry->numParameters = args->geti();
     newLibraryEntry->parameterNamesRT = static_cast<char**>(RTAlloc(inWorld, newLibraryEntry->numParameters));
     for (int i = 0; i < newLibraryEntry->numParameters; i++) {
@@ -328,7 +330,9 @@ STAGE3_RT -> STAGE4_NRT : deleteOldVm
 ```
 */
             // clang-format on
-            dynGen->updateCode(entry->script);
+            if (entry->updateUnits) {
+                dynGen->updateCode(entry->script);
+            }
         }
     }
     return true;

--- a/src/library.h
+++ b/src/library.h
@@ -149,6 +149,7 @@ struct NewDynGenLibraryEntry {
      */
     char** parameterNamesRT;
     int numParameters;
+    bool updateUnits;
 
     /*! @brief the newly received script - NRT managed */
     DynGenScript* script;


### PR DESCRIPTION
if `update` is `true`, all running DynGen instances for this DynGenDef will be updated to the new code. Otherwise, they will continue with the old code.

Typical usage situation: You are playing note patterns using DynGen as the instrument. You then want to change the script, but you do not want existing notes to suddenly change their sound; only new notes should be affected. Currently this is not possible (without changing the instrument).

---

Alternatively, we could add an `update` argument to `DynGen` to control the update behavior per UGen.

Or we could actually combine both approaches, i.e. the code is only updated if both the UGen and the `send` method say so.

What are your thoughts on this?

