### PR TITLE
Fix node deletion in freeing of a DynGen instance

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -119,7 +119,7 @@ void Library::freeNode(CodeLibrary* node, World* world) {
     auto curNode = gLibrary;
     CodeLibrary* prevNode = nullptr;
     while (curNode != nullptr && curNode->mID != node->mID) {
-        prevNode = node;
+        prevNode = curNode;
         curNode = curNode->mNext;
     }
     if (prevNode != nullptr) {


### PR DESCRIPTION
I'll release 0.3.1 after this has been merged.