### PR TITLE
disable buffer aliasing

### DIFF
--- a/src/HelpSource/Classes/DynGen.schelp
+++ b/src/HelpSource/Classes/DynGen.schelp
@@ -596,20 +596,9 @@ CODE::
 // The following code works for any number of input and output channels:
 (
 DynGenDef(\mcGain, "
-@init
-buf = 0;
-
-@sample
-// inputs may alias outputs so we have to make a copy!
-chan = 0;
-loop(numIn,
-    buf[chan] = in(chan);
-    chan += 1;
-);
-// read from buffer and apply gain
 chan = 0;
 loop(numOut,
-    out(chan) = buf[chan] * _gain;
+    out(chan) = in(chan) * _gain;
     chan += 1;
 );
 ").send;

--- a/src/dyngen.cpp
+++ b/src/dyngen.cpp
@@ -213,8 +213,9 @@ PluginLoad("DynGen") {
 
     NSEEL_init();
 
-    registerUnit<DynGen>(inTable, "DynGen", false);
-    registerUnit<DynGen>(inTable, "DynGenRT", false);
+    // disable buffer aliasing so that users do not have to worry about
+    // 'out*' variables potentially aliasing 'in*' variables.
+    registerUnit<DynGen>(inTable, "DynGen", true);
 
     ft->fDefinePlugInCmd("dyngenfile", Library::dyngenAddFileCallback, nullptr);
 


### PR DESCRIPTION
Disables buffer aliasing as suggested in https://github.com/capital-G/DynGen/issues/77.

I couldn't measure any performance impact, so I think this should be fine. There are also a few core plugins that do this (`PlayBuf`, `TGrains`, `Demand`, `Duty`, `DemandEnvGen`, `TDuty`, `GrainIn`, `GrainSin`, `GrainFM`, `GrainBuf`, `Warp1`, `Balance2`, `PanB2`, `PanAZ`, `DecodeB2` and `PartConv`)