### PR TITLE
Initialize in0, in1, etc. in the @init and @block section

### DIFF
--- a/src/HelpSource/Classes/DynGen.schelp
+++ b/src/HelpSource/Classes/DynGen.schelp
@@ -423,8 +423,11 @@ SUBSECTION:: DynGen sections
 If no section block is given, the whole script will be evaluated for each sample.
 
 A section that starts with the CODE::@init:: header is only evaluated once during initialization.
+CODE::in0::, CODE::in1::, etc. and all the parameters contain their initial values.
 
 A section that starts with CODE::@block:: is evaluated before each block, see LINK::Classes/ServerOptions#-blockSize:: (aka the rate that CODE::.kr:: is running at).
+CODE::in0::, CODE::in1::, etc. and all audio-rate parameters are set to the first sample of the new block.
+Control-rate parameters are set to their new value (without interpolation!).
 
 If any of these two sections is provided, it is necessary to mark the per-sample script with the CODE::@sample:: header.
 

--- a/src/eel2_adapter.h
+++ b/src/eel2_adapter.h
@@ -77,6 +77,11 @@ public:
             std::copy_n(newParamValues, mNumParameters, mPrevParamValues.get());
 
             if (mInitCode) {
+                // initialize in0, in1, etc. variables to first input sample
+                for (int inChannel = 0; inChannel < mNumInputChannels; inChannel++) {
+                    *mInputs[inChannel] = static_cast<double>(inBuf[inChannel][0]);
+                }
+
                 NSEEL_code_execute(mInitCode);
             }
 
@@ -92,6 +97,11 @@ public:
         }
 
         if (mBlockCode) {
+            // update in0, in1, etc. variables to first input sample
+            for (int inChannel = 0; inChannel < mNumInputChannels; inChannel++) {
+                *mInputs[inChannel] = static_cast<double>(inBuf[inChannel][0]);
+            }
+
             // update parameters, but do *not* update the cache!
             // NOTE: the behavior of control-rate parameters slightly differs
             // between the @block section and the @sample section:

--- a/testsuite.scd
+++ b/testsuite.scd
@@ -14,6 +14,8 @@
 		\testDelete,
 		\testDeleteWhileRunning,
 		\testDeleteAll,
+		\testInputInitSection,
+		\testInputBlockSection,
 		\testParamsInitSection,
 		\testParamsBlockSection,
 		\testParamsInterpolation,
@@ -324,10 +326,65 @@
 		deleteSuccess.and(playSuccess);
 	},
 
+	testInputInitSection: {
+		// in the @init section, in0, in1, etc. should be initialized to the first input sample
+		var condition = Condition();
+		var success = false;
+		// this code outputs the first derivative of the inputs
+		DynGenDef(\testInputInitSection, "
+            @init
+            prev0 = in0; prev1 = in1;
+            @sample
+            out0 = in0 - prev0; prev0 = in0;
+            out1 = in1 - prev1; prev1 = in1;"
+		).send;
+		s.sync;
+		{
+			DynGen.ar(2, \testInputInitSection, LFNoise1.ar([100, 200]), sync: 1.0);
+		}.loadToFloatArray(0.01, action: {|sig|
+			// the first sample must be 0.0 in both channels
+			success = sig[0..1].every(_ == 0.0);
+			condition.unhang;
+		});
+		condition.hang;
+		success;
+	},
+
+	testInputBlockSection: {
+		// in the @block section in0, in1, etc. should be initialized to the first input sample
+		var condition = Condition();
+		var success = false;
+		DynGenDef(\testInputBlockSection, "
+            @block
+            x = in0;
+            @sample
+            out0 = in0;
+            out1 = x;"
+		).send;
+		s.sync;
+		{
+			DynGen.ar(2, \testInputBlockSection, LFNoise1.ar(200), sync: 1.0);
+		}.loadToFloatArray(0.01, action: {|sig|
+			var blockSize = s.options.blockSize;
+			success = true;
+			// the two outputs should be equal at the beginning of every block.
+			sig.pairsDo { |a, b, i|
+				if ((i.div(2) % blockSize) == 0) {
+					if (a != b) { success = false }
+				}
+			};
+			condition.unhang;
+		});
+		condition.hang;
+		success;
+
+	},
+
 	testParamsInitSection: {
 		// \ir, \kr and \ar parameters should all have the same value in the @init section.
 		var condition = Condition();
 		var success = false;
+		var value = 0.5;
 		DynGenDef(\testParamsInitSection, "
             @init
             x = _x; y = _y; z = _z;
@@ -335,11 +392,11 @@
             out0 = x; out1 = y; out2 = z;"
 		).send;
 		s.sync;
-		{ |a=0.5|
+		{
 			DynGen.ar(3, \testParamsInitSection,
-				params: [ x: 0.5, y: a, z: K2A.ar(0.5) ], sync: 1.0);
+				params: [ x: value, y: \a.kr(value), z: K2A.ar(value) ], sync: 1.0);
 		}.loadToFloatArray(0.01, action: {|sig|
-			success = sig[0..2].every(_ == 0.5);
+			success = sig[0..2].every(_ == value);
 			condition.unhang;
 		});
 		condition.hang;


### PR DESCRIPTION
In the `@init` and `@block` sections, the `in0`, `in1`, etc. variables are now initialized to the first sample of the new block. 

Previously, `in0` was always 0 in the `@init` section; in the `@block` section it contained the *last* sample value of the previous `@sample` section.

For example, this is necessary if you want to calculate the first derivative of an input signal and get the correct result on the first sample:
```
@init
prev = in0;
@sample
out0 = in0 - prev; prev = in0;
```
