### PR TITLE
Add 'sampleIndex'  and 'blockNum' variables

### DIFF
--- a/src/HelpSource/Classes/DynGen.schelp
+++ b/src/HelpSource/Classes/DynGen.schelp
@@ -368,7 +368,7 @@ TABLE::
 ## STRONG::variable name:: || STRONG::comment::
 ## CODE::in0::, CODE::in1::, etc. || contains the current sample value of the given input channel. If the channel number is out-of-range, the variable contains 0.0.
 ## CODE::out0::, CODE::out1::, etc. || represents the current sample of the given output channel. If the channel number is out-of-range, any assignments will be ignored.
-## CODE::sampleIndex:: || the index of the current sample in a CODE::@sample:: block.
+## CODE::sampleNum:: || the number/index of the current sample in this block (starting from 0). This is only valid in the CODE::@sample:: section.
 ## CODE::blockNum:: || the number of the current block, starting from 0.
 ::
 

--- a/src/eel2_adapter.cpp
+++ b/src/eel2_adapter.cpp
@@ -137,7 +137,7 @@ bool EEL2Adapter::init(const DynGenScript& script, const int* parameterIndices, 
     *NSEEL_VM_regvar(mEelState, "numOut") = mNumOutputChannels;
 
     mBlockNum = NSEEL_VM_regvar(mEelState, "blockNum");
-    mSampleIndex = NSEEL_VM_regvar(mEelState, "sampleIndex");
+    mSampleNum = NSEEL_VM_regvar(mEelState, "sampleNum");
 
     auto compileFlags = NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS | NSEEL_CODE_COMPILE_FLAG_COMMONFUNCS_RESET
         | NSEEL_CODE_COMPILE_FLAG_NOFPSTATE;

--- a/src/eel2_adapter.h
+++ b/src/eel2_adapter.h
@@ -131,8 +131,8 @@ public:
         double slopeFactor = 1.0 / static_cast<double>(numSamples);
 
         for (int i = 0; i < numSamples; i++) {
-            // update "sampleIndex" variable
-            *mSampleIndex = static_cast<double>(i);
+            // update "sampleNum" variable
+            *mSampleNum = static_cast<double>(i);
 
             // copy input samples to in0, in1, etc. variables
             for (int inChannel = 0; inChannel < mNumInputChannels; inChannel++) {
@@ -198,7 +198,7 @@ private:
     uint64_t mBlockCounter = 0;
 
     double* mBlockNum = nullptr;
-    double* mSampleIndex = nullptr;
+    double* mSampleNum = nullptr;
     std::unique_ptr<double*[]> mInputs;
     std::unique_ptr<double*[]> mOutputs;
     std::unique_ptr<double*[]> mParameters;

--- a/testsuite.scd
+++ b/testsuite.scd
@@ -248,7 +248,7 @@
 		var success = false;
 		var condition = Condition();
 
-		DynGenDef(\testVars, "out0=sampleIndex;out1=blockNum;").send;
+		DynGenDef(\testVars, "out0=sampleNum;out1=blockNum;").send;
 		s.sync;
 		{
 			DynGen.ar(2, \testVars, sync: 1.0);


### PR DESCRIPTION
This PR adds the following two variables:

- `sampleIndex`: the index of the current sample in the `@sample` block. This is useful if you want to perform some action depending on the sample index. Currently, you would have to maintain your own counter and reset it in the `@block` section. A typical example would be to make a snapshot of the first sample of a block.

- `blockNum`: the current block number, starting at 0. This is handy if you want to perform a certain action only every N blocks. A typical example would be printing sample values for debugging purposes, but only every few blocks, to avoid spamming the console:
  ```
  @sample
  temp = complexCalculation(in0);
  (blockNum % 100) == 0 ? (
      print(temp);
   );
   out0 = moreCalculation(temp);
  ```
  Without the `blockNum` variable we would have to add a `@block` section and increment a counter.

Not sure about the naming. Feel free to suggest better names :)